### PR TITLE
Add starter WooCommerce plugin template

### DIFF
--- a/peopo-mercari-order/includes/admin/class-peopo-mercari-order-admin.php
+++ b/peopo-mercari-order/includes/admin/class-peopo-mercari-order-admin.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Admin functionality for Peopo Mercari Order plugin.
+ *
+ * @package Peopo_Mercari_Order
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Handles admin pages and settings.
+ */
+class Peopo_Mercari_Order_Admin {
+
+    /**
+     * Register admin menu entry.
+     */
+    public function register_menu() {
+        add_menu_page(
+            __( 'Mercari Orders', 'peopo-mercari-order' ),
+            __( 'Mercari Orders', 'peopo-mercari-order' ),
+            'manage_options',
+            'peopo-mercari-order',
+            array( $this, 'render_settings_page' ),
+            'dashicons-cart'
+        );
+    }
+
+    /**
+     * Register plugin settings.
+     */
+    public function register_settings() {
+        register_setting( 'peopo_mercari_order_settings', 'peopo_mercari_order_api_key' );
+        register_setting( 'peopo_mercari_order_settings', 'peopo_mercari_order_api_secret' );
+    }
+
+    /**
+     * Render the settings page for the plugin.
+     */
+    public function render_settings_page() {
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'Mercari API Settings', 'peopo-mercari-order' ); ?></h1>
+            <form action="options.php" method="post">
+                <?php
+                settings_fields( 'peopo_mercari_order_settings' );
+                do_settings_sections( 'peopo_mercari_order_settings' );
+                ?>
+                <table class="form-table">
+                    <tr>
+                        <th scope="row">
+                            <label for="peopo-mercari-order-api-key"><?php esc_html_e( 'API Key', 'peopo-mercari-order' ); ?></label>
+                        </th>
+                        <td>
+                            <input type="text" id="peopo-mercari-order-api-key" name="peopo_mercari_order_api_key" value="<?php echo esc_attr( get_option( 'peopo_mercari_order_api_key', '' ) ); ?>" class="regular-text">
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">
+                            <label for="peopo-mercari-order-api-secret"><?php esc_html_e( 'API Secret', 'peopo-mercari-order' ); ?></label>
+                        </th>
+                        <td>
+                            <input type="password" id="peopo-mercari-order-api-secret" name="peopo_mercari_order_api_secret" value="<?php echo esc_attr( get_option( 'peopo_mercari_order_api_secret', '' ) ); ?>" class="regular-text">
+                        </td>
+                    </tr>
+                </table>
+                <?php submit_button(); ?>
+            </form>
+        </div>
+        <?php
+    }
+}

--- a/peopo-mercari-order/includes/class-peopo-mercari-order.php
+++ b/peopo-mercari-order/includes/class-peopo-mercari-order.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Main plugin class
+ *
+ * @package Peopo_Mercari_Order
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+require_once PEOPO_MERCARI_ORDER_PATH . 'includes/admin/class-peopo-mercari-order-admin.php';
+
+/**
+ * The core plugin class.
+ */
+class Peopo_Mercari_Order {
+
+    /**
+     * Admin functionality controller.
+     *
+     * @var Peopo_Mercari_Order_Admin
+     */
+    protected $admin;
+
+    /**
+     * Initialize the plugin by setting up hooks.
+     */
+    public function __construct() {
+        $this->admin = new Peopo_Mercari_Order_Admin();
+    }
+
+    /**
+     * Register all of the hooks for admin functionality.
+     */
+    public function run() {
+        add_action( 'init', array( $this, 'load_textdomain' ) );
+        add_action( 'admin_menu', array( $this->admin, 'register_menu' ) );
+        add_action( 'admin_init', array( $this->admin, 'register_settings' ) );
+        add_action( 'woocommerce_order_status_completed', array( $this, 'handle_completed_order' ), 10, 1 );
+    }
+
+    /**
+     * Load plugin text domain for translations.
+     */
+    public function load_textdomain() {
+        load_plugin_textdomain( 'peopo-mercari-order', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
+    }
+
+    /**
+     * Handle WooCommerce order completion.
+     *
+     * @param int $order_id Order ID.
+     */
+    public function handle_completed_order( $order_id ) {
+        if ( ! $order_id ) {
+            return;
+        }
+
+        $order = wc_get_order( $order_id );
+
+        if ( ! $order ) {
+            return;
+        }
+
+        /**
+         * Example: Send order data to Mercari API.
+         * Replace this with real API integration.
+         */
+        do_action( 'peopo_mercari_order_sync', $order );
+    }
+}

--- a/peopo-mercari-order/languages/index.php
+++ b/peopo-mercari-order/languages/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/peopo-mercari-order/peopo-mercari-order.php
+++ b/peopo-mercari-order/peopo-mercari-order.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Plugin Name:       Peopo Mercari Order
+ * Plugin URI:        https://example.com/plugins/peopo-mercari-order
+ * Description:       Template plugin to integrate WooCommerce with Mercari order management.
+ * Version:           0.1.0
+ * Requires at least: 5.8
+ * Requires PHP:      7.4
+ * Author:            Your Name
+ * Author URI:        https://example.com
+ * License:           GPL-2.0-or-later
+ * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
+ * Text Domain:       peopo-mercari-order
+ * Domain Path:       /languages
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+if ( ! defined( 'PEOPO_MERCARI_ORDER_VERSION' ) ) {
+    define( 'PEOPO_MERCARI_ORDER_VERSION', '0.1.0' );
+}
+
+if ( ! defined( 'PEOPO_MERCARI_ORDER_PATH' ) ) {
+    define( 'PEOPO_MERCARI_ORDER_PATH', plugin_dir_path( __FILE__ ) );
+}
+
+if ( ! defined( 'PEOPO_MERCARI_ORDER_URL' ) ) {
+    define( 'PEOPO_MERCARI_ORDER_URL', plugin_dir_url( __FILE__ ) );
+}
+
+require_once PEOPO_MERCARI_ORDER_PATH . 'includes/class-peopo-mercari-order.php';
+
+/**
+ * Begins execution of the plugin.
+ */
+function peopo_mercari_order_run() {
+    $plugin = new Peopo_Mercari_Order();
+    $plugin->run();
+}
+add_action( 'plugins_loaded', 'peopo_mercari_order_run' );

--- a/peopo-mercari-order/readme.txt
+++ b/peopo-mercari-order/readme.txt
@@ -1,0 +1,33 @@
+=== Peopo Mercari Order ===
+Contributors: your-name
+Requires at least: 5.8
+Tested up to: 6.4
+Requires PHP: 7.4
+Stable tag: 0.1.0
+License: GPLv2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+
+== Description ==
+
+This is a starter template for integrating WooCommerce with Mercari order management. It registers an admin settings page to store API credentials and exposes a hook to sync completed orders with external services.
+
+== Installation ==
+
+1. Upload the `peopo-mercari-order` folder to the `/wp-content/plugins/` directory.
+2. Activate the plugin through the 'Plugins' screen in WordPress.
+3. Navigate to **Mercari Orders** in the WordPress admin menu to enter your API credentials.
+
+== Frequently Asked Questions ==
+
+= Does this plugin sync orders automatically? =
+
+The template triggers the `peopo_mercari_order_sync` action whenever a WooCommerce order is marked as completed. Hook into this action to connect with external services.
+
+= Can I extend this plugin? =
+
+Yes. Use the provided hooks or extend the classes located in the `includes` directory to add functionality.
+
+== Changelog ==
+
+= 0.1.0 =
+* Initial release.


### PR DESCRIPTION
## Summary
- add initial Peopo Mercari Order plugin bootstrap for WordPress
- scaffold main plugin class, admin settings page, and WooCommerce hooks
- document installation steps and usage in plugin readme

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfeb4e6ec0832bb9a8fe6ed809fd9a